### PR TITLE
Feat/data-transfer-objects

### DIFF
--- a/ponzu-back/src/dto/anime.rs
+++ b/ponzu-back/src/dto/anime.rs
@@ -7,7 +7,8 @@ use crate::utils::bson::{
     deserialize_option_hex_string_from_object_id, serialize_option_bson_datetime_as_rfc3339_string,
     serialize_option_hex_string_as_object_id,
 };
-use mongodb::bson::DateTime;
+use mongodb::bson::{doc, to_bson, DateTime, Document};
+use mongodb::options::UpdateModifications;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -259,6 +260,231 @@ impl From<CreateAnimeDto> for Anime {
             external: dto.external,
             streaming: dto.streaming,
         }
+    }
+}
+
+impl From<UpdateAnimeDto> for UpdateModifications {
+    fn from(dto: UpdateAnimeDto) -> Self {
+        let mut doc = Document::new();
+
+        if let Some(mal_id) = dto.mal_id {
+            doc.insert(
+                "mal_id",
+                to_bson(&mal_id).expect("Failed to convert mal_id to bson"),
+            );
+        }
+        if let Some(images) = dto.images {
+            doc.insert(
+                "images",
+                to_bson(&images).expect("Failed to convert images to bson"),
+            );
+        }
+        if let Some(trailer) = dto.trailer {
+            doc.insert(
+                "trailer",
+                to_bson(&trailer).expect("Failed to convert trailer to bson"),
+            );
+        }
+        if let Some(approved) = dto.approved {
+            doc.insert(
+                "approved",
+                to_bson(&approved).expect("Failed to convert approved to bson"),
+            );
+        }
+        if let Some(titles) = dto.titles {
+            doc.insert(
+                "titles",
+                to_bson(&titles).expect("Failed to convert titles to bson"),
+            );
+        }
+        if let Some(title) = dto.title {
+            doc.insert(
+                "title",
+                to_bson(&title).expect("Failed to convert title to bson"),
+            );
+        }
+        if let Some(title_english) = dto.title_english {
+            doc.insert(
+                "title_english",
+                to_bson(&title_english).expect("Failed to convert title_english to bson"),
+            );
+        }
+        if let Some(title_japanese) = dto.title_japanese {
+            doc.insert(
+                "title_japanese",
+                to_bson(&title_japanese).expect("Failed to convert title_japanese to bson"),
+            );
+        }
+        if let Some(title_synonyms) = dto.title_synonyms {
+            doc.insert(
+                "title_synonyms",
+                to_bson(&title_synonyms).expect("Failed to convert title_synonyms to bson"),
+            );
+        }
+        if let Some(r#type) = dto.r#type {
+            doc.insert(
+                "type",
+                to_bson(&r#type).expect("Failed to convert type to bson"),
+            );
+        }
+        if let Some(source) = dto.source {
+            doc.insert(
+                "source",
+                to_bson(&source).expect("Failed to convert source to bson"),
+            );
+        }
+        if let Some(episodes) = dto.episodes {
+            doc.insert(
+                "episodes",
+                to_bson(&episodes).expect("Failed to convert episodes to bson"),
+            );
+        }
+        if let Some(status) = dto.status {
+            doc.insert(
+                "status",
+                to_bson(&status).expect("Failed to convert status to bson"),
+            );
+        }
+        if let Some(airing) = dto.airing {
+            doc.insert(
+                "airing",
+                to_bson(&airing).expect("Failed to convert airing to bson"),
+            );
+        }
+        if let Some(aired) = dto.aired {
+            doc.insert(
+                "aired",
+                to_bson(&aired).expect("Failed to convert aired to bson"),
+            );
+        }
+        if let Some(duration) = dto.duration {
+            doc.insert(
+                "duration",
+                to_bson(&duration).expect("Failed to convert duration to bson"),
+            );
+        }
+        if let Some(rating) = dto.rating {
+            doc.insert(
+                "rating",
+                to_bson(&rating).expect("Failed to convert rating to bson"),
+            );
+        }
+        if let Some(scored_by) = dto.scored_by {
+            doc.insert(
+                "scored_by",
+                to_bson(&scored_by).expect("Failed to convert scored_by to bson"),
+            );
+        }
+        if let Some(members) = dto.members {
+            doc.insert(
+                "members",
+                to_bson(&members).expect("Failed to convert members to bson"),
+            );
+        }
+        if let Some(favorites) = dto.favorites {
+            doc.insert(
+                "favorites",
+                to_bson(&favorites).expect("Failed to convert favorites to bson"),
+            );
+        }
+        if let Some(synopsis) = dto.synopsis {
+            doc.insert(
+                "synopsis",
+                to_bson(&synopsis).expect("Failed to convert synopsis to bson"),
+            );
+        }
+        if let Some(background) = dto.background {
+            doc.insert(
+                "background",
+                to_bson(&background).expect("Failed to convert background to bson"),
+            );
+        }
+        if let Some(season) = dto.season {
+            doc.insert(
+                "season",
+                to_bson(&season).expect("Failed to convert season to bson"),
+            );
+        }
+        if let Some(year) = dto.year {
+            doc.insert(
+                "year",
+                to_bson(&year).expect("Failed to convert year to bson"),
+            );
+        }
+        if let Some(broadcast) = dto.broadcast {
+            doc.insert(
+                "broadcast",
+                to_bson(&broadcast).expect("Failed to convert broadcast to bson"),
+            );
+        }
+        if let Some(producers) = dto.producers {
+            doc.insert(
+                "producers",
+                to_bson(&producers).expect("Failed to convert producers to bson"),
+            );
+        }
+        if let Some(licensors) = dto.licensors {
+            doc.insert(
+                "licensors",
+                to_bson(&licensors).expect("Failed to convert licensors to bson"),
+            );
+        }
+        if let Some(studios) = dto.studios {
+            doc.insert(
+                "studios",
+                to_bson(&studios).expect("Failed to convert studios to bson"),
+            );
+        }
+        if let Some(genres) = dto.genres {
+            doc.insert(
+                "genres",
+                to_bson(&genres).expect("Failed to convert genres to bson"),
+            );
+        }
+        if let Some(explicit_genres) = dto.explicit_genres {
+            doc.insert(
+                "explicit_genres",
+                to_bson(&explicit_genres).expect("Failed to convert explicit_genres to bson"),
+            );
+        }
+        if let Some(themes) = dto.themes {
+            doc.insert(
+                "themes",
+                to_bson(&themes).expect("Failed to convert themes to bson"),
+            );
+        }
+        if let Some(demographics) = dto.demographics {
+            doc.insert(
+                "demographics",
+                to_bson(&demographics).expect("Failed to convert demographics to bson"),
+            );
+        }
+        if let Some(relations) = dto.relations {
+            doc.insert(
+                "relations",
+                to_bson(&relations).expect("Failed to convert relations to bson"),
+            );
+        }
+        if let Some(theme) = dto.theme {
+            doc.insert(
+                "theme",
+                to_bson(&theme).expect("Failed to convert theme to bson"),
+            );
+        }
+        if let Some(external) = dto.external {
+            doc.insert(
+                "external",
+                to_bson(&external).expect("Failed to convert external to bson"),
+            );
+        }
+        if let Some(streaming) = dto.streaming {
+            doc.insert(
+                "streaming",
+                to_bson(&streaming).expect("Failed to convert streaming to bson"),
+            );
+        }
+
+        UpdateModifications::Document(doc)
     }
 }
 

--- a/ponzu-back/src/dto/anime.rs
+++ b/ponzu-back/src/dto/anime.rs
@@ -1,0 +1,341 @@
+use crate::models::anime::{Aired, AiredProp, AiredPropFromTo, Anime, Broadcast};
+use crate::models::genre::Genre;
+use crate::models::producer::Producer;
+use crate::types::links::{ExternalLink, Images, Trailer};
+use crate::types::title_meta::{MalEntity, Relation, Theme, Title};
+use mongodb::bson::DateTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AnimeDto {
+    #[serde(
+        rename = "_id",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_hex_string_as_object_id",
+        deserialize_with = "deserialize_option_hex_string_from_object_id"
+    )]
+    pub id: Option<String>,
+    pub mal_id: u64,
+    pub images: Images,
+    pub trailer: Trailer,
+    pub approved: bool,
+    pub titles: Vec<Title>,
+    pub title: String,
+    pub title_english: String,
+    pub title_japanese: String,
+    pub title_synonyms: Vec<String>,
+    pub r#type: String,
+    pub source: String,
+    pub episodes: Option<u32>,
+    pub status: String,
+    pub airing: bool,
+    pub aired: Option<AiredDto>,
+    pub duration: String,
+    pub rating: String,
+    pub scored_by: u64,
+    pub members: u64,
+    pub favorites: u64,
+    pub synopsis: String,
+    pub background: String,
+    pub season: String,
+    pub year: Option<u32>,
+    pub broadcast: Option<BroadcastDto>,
+    pub producers: Vec<Producer>,
+    pub licensors: Vec<MalEntity>,
+    pub studios: Vec<MalEntity>,
+    pub genres: Vec<Genre>,
+    pub explicit_genres: Vec<MalEntity>,
+    pub themes: Vec<MalEntity>,
+    pub demographics: Vec<MalEntity>,
+    pub relations: Vec<Relation>,
+    pub theme: Option<Theme>,
+    pub external: Vec<ExternalLink>,
+    pub streaming: Vec<ExternalLink>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BroadcastDto {
+    pub day: String,
+    pub time: String,
+    pub timezone: String,
+    pub string: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AiredDto {
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_bson_datetime_as_rfc3339_string"
+    )]
+    pub from: Option<DateTime>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_bson_datetime_as_rfc3339_string"
+    )]
+    pub to: Option<DateTime>,
+    pub prop: AiredPropDto,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AiredPropDto {
+    pub from: AiredPropFromToDto,
+    pub to: AiredPropFromToDto,
+    pub string: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AiredPropFromToDto {
+    pub day: i32,
+    pub month: i32,
+    pub year: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateAnimeDto {
+    pub mal_id: u64,
+    pub images: Images,
+    pub trailer: Trailer,
+    pub approved: bool,
+    pub titles: Vec<Title>,
+    pub title: String,
+    pub title_english: String,
+    pub title_japanese: String,
+    pub title_synonyms: Vec<String>,
+    pub r#type: String,
+    pub source: String,
+    pub episodes: Option<u32>,
+    pub status: String,
+    pub airing: bool,
+    pub aired: Option<AiredDto>,
+    pub duration: String,
+    pub rating: String,
+    pub scored_by: u64,
+    pub members: u64,
+    pub favorites: u64,
+    pub synopsis: String,
+    pub background: String,
+    pub season: String,
+    pub year: Option<u32>,
+    pub broadcast: Option<BroadcastDto>,
+    pub producers: Vec<Producer>,
+    pub licensors: Vec<MalEntity>,
+    pub studios: Vec<MalEntity>,
+    pub genres: Vec<Genre>,
+    pub explicit_genres: Vec<MalEntity>,
+    pub themes: Vec<MalEntity>,
+    pub demographics: Vec<MalEntity>,
+    pub relations: Vec<Relation>,
+    pub theme: Option<Theme>,
+    pub external: Vec<ExternalLink>,
+    pub streaming: Vec<ExternalLink>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateAnimeDto {
+    pub mal_id: Option<u64>,
+    pub images: Option<Images>,
+    pub trailer: Option<Trailer>,
+    pub approved: Option<bool>,
+    pub titles: Option<Vec<Title>>,
+    pub title: Option<String>,
+    pub title_english: Option<String>,
+    pub title_japanese: Option<String>,
+    pub title_synonyms: Option<Vec<String>>,
+    pub r#type: Option<String>,
+    pub source: Option<String>,
+    pub episodes: Option<u32>,
+    pub status: Option<String>,
+    pub airing: Option<bool>,
+    pub aired: Option<AiredDto>,
+    pub duration: Option<String>,
+    pub rating: Option<String>,
+    pub scored_by: Option<u64>,
+    pub members: Option<u64>,
+    pub favorites: Option<u64>,
+    pub synopsis: Option<String>,
+    pub background: Option<String>,
+    pub season: Option<String>,
+    pub year: Option<u32>,
+    pub broadcast: Option<BroadcastDto>,
+    pub producers: Option<Vec<Producer>>,
+    pub licensors: Option<Vec<MalEntity>>,
+    pub studios: Option<Vec<MalEntity>>,
+    pub genres: Option<Vec<Genre>>,
+    pub explicit_genres: Option<Vec<MalEntity>>,
+    pub themes: Option<Vec<MalEntity>>,
+    pub demographics: Option<Vec<MalEntity>>,
+    pub relations: Option<Vec<Relation>>,
+    pub theme: Option<Theme>,
+    pub external: Option<Vec<ExternalLink>>,
+    pub streaming: Option<Vec<ExternalLink>>,
+}
+
+impl From<Anime> for AnimeDto {
+    fn from(anime: Anime) -> Self {
+        Self {
+            id: anime.id,
+            mal_id: anime.mal_id,
+            images: anime.images,
+            trailer: anime.trailer,
+            approved: anime.approved,
+            titles: anime.titles,
+            title: anime.title,
+            title_english: anime.title_english,
+            title_japanese: anime.title_japanese,
+            title_synonyms: anime.title_synonyms,
+            r#type: anime.r#type,
+            source: anime.source,
+            episodes: anime.episodes,
+            status: anime.status,
+            airing: anime.airing,
+            aired: anime.aired.map(Into::into),
+            duration: anime.duration,
+            rating: anime.rating,
+            scored_by: anime.scored_by,
+            members: anime.members,
+            favorites: anime.favorites,
+            synopsis: anime.synopsis,
+            background: anime.background,
+            season: anime.season,
+            year: anime.year,
+            broadcast: anime.broadcast.map(Into::into),
+            producers: anime.producers,
+            licensors: anime.licensors,
+            studios: anime.studios,
+            genres: anime.genres,
+            explicit_genres: anime.explicit_genres,
+            themes: anime.themes,
+            demographics: anime.demographics,
+            relations: anime.relations,
+            theme: anime.theme,
+            external: anime.external,
+            streaming: anime.streaming,
+        }
+    }
+}
+
+impl From<CreateAnimeDto> for Anime {
+    fn from(dto: CreateAnimeDto) -> Self {
+        Self {
+            id: None,
+            mal_id: dto.mal_id,
+            images: dto.images,
+            trailer: dto.trailer,
+            approved: dto.approved,
+            titles: dto.titles,
+            title: dto.title,
+            title_english: dto.title_english,
+            title_japanese: dto.title_japanese,
+            title_synonyms: dto.title_synonyms,
+            r#type: dto.r#type,
+            source: dto.source,
+            episodes: dto.episodes,
+            status: dto.status,
+            airing: dto.airing,
+            aired: dto.aired.map(Into::into),
+            duration: dto.duration,
+            rating: dto.rating,
+            scored_by: dto.scored_by,
+            members: dto.members,
+            favorites: dto.favorites,
+            synopsis: dto.synopsis,
+            background: dto.background,
+            season: dto.season,
+            year: dto.year,
+            broadcast: dto.broadcast.map(Into::into),
+            producers: dto.producers,
+            licensors: dto.licensors,
+            studios: dto.studios,
+            genres: dto.genres,
+            explicit_genres: dto.explicit_genres,
+            themes: dto.themes,
+            demographics: dto.demographics,
+            relations: dto.relations,
+            theme: dto.theme,
+            external: dto.external,
+            streaming: dto.streaming,
+        }
+    }
+}
+
+impl From<Broadcast> for BroadcastDto {
+    fn from(broadcast: Broadcast) -> Self {
+        Self {
+            day: broadcast.day,
+            time: broadcast.time,
+            timezone: broadcast.timezone,
+            string: broadcast.string,
+        }
+    }
+}
+
+impl From<BroadcastDto> for Broadcast {
+    fn from(dto: BroadcastDto) -> Self {
+        Self {
+            day: dto.day,
+            time: dto.time,
+            timezone: dto.timezone,
+            string: dto.string,
+        }
+    }
+}
+
+impl From<Aired> for AiredDto {
+    fn from(aired: Aired) -> Self {
+        Self {
+            from: aired.from,
+            to: aired.to,
+            prop: aired.prop.into(),
+        }
+    }
+}
+
+impl From<AiredDto> for Aired {
+    fn from(dto: AiredDto) -> Self {
+        Self {
+            from: dto.from,
+            to: dto.to,
+            prop: dto.prop.into(),
+        }
+    }
+}
+
+impl From<AiredProp> for AiredPropDto {
+    fn from(prop: AiredProp) -> Self {
+        Self {
+            from: prop.from.into(),
+            to: prop.to.into(),
+            string: prop.string,
+        }
+    }
+}
+
+impl From<AiredPropDto> for AiredProp {
+    fn from(dto: AiredPropDto) -> Self {
+        Self {
+            from: dto.from.into(),
+            to: dto.to.into(),
+            string: dto.string,
+        }
+    }
+}
+
+impl From<AiredPropFromTo> for AiredPropFromToDto {
+    fn from(prop: AiredPropFromTo) -> Self {
+        Self {
+            day: prop.day,
+            month: prop.month,
+            year: prop.year,
+        }
+    }
+}
+
+impl From<AiredPropFromToDto> for AiredPropFromTo {
+    fn from(dto: AiredPropFromToDto) -> Self {
+        Self {
+            day: dto.day,
+            month: dto.month,
+            year: dto.year,
+        }
+    }
+}

--- a/ponzu-back/src/dto/anime.rs
+++ b/ponzu-back/src/dto/anime.rs
@@ -3,6 +3,10 @@ use crate::models::genre::Genre;
 use crate::models::producer::Producer;
 use crate::types::links::{ExternalLink, Images, Trailer};
 use crate::types::title_meta::{MalEntity, Relation, Theme, Title};
+use crate::utils::bson::{
+    deserialize_option_hex_string_from_object_id, serialize_option_bson_datetime_as_rfc3339_string,
+    serialize_option_hex_string_as_object_id,
+};
 use mongodb::bson::DateTime;
 use serde::{Deserialize, Serialize};
 

--- a/ponzu-back/src/dto/character.rs
+++ b/ponzu-back/src/dto/character.rs
@@ -1,7 +1,9 @@
 use crate::models::character::{Character, CharacterMedia, CharacterVoice};
 use crate::types::links::Images;
+use crate::utils::bson::{
+    deserialize_option_hex_string_from_object_id, serialize_option_hex_string_as_object_id,
+};
 use serde::{Deserialize, Serialize};
-
 /// A simplified character object.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CharacterReference {

--- a/ponzu-back/src/dto/character.rs
+++ b/ponzu-back/src/dto/character.rs
@@ -3,7 +3,10 @@ use crate::types::links::Images;
 use crate::utils::bson::{
     deserialize_option_hex_string_from_object_id, serialize_option_hex_string_as_object_id,
 };
+use mongodb::bson::{to_bson, Document};
+use mongodb::options::UpdateModifications;
 use serde::{Deserialize, Serialize};
+
 /// A simplified character object.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CharacterReference {
@@ -112,6 +115,78 @@ impl From<CreateCharacterDto> for Character {
             manga: dto.manga.into_iter().map(Into::into).collect(),
             voices: dto.voices.into_iter().map(Into::into).collect(),
         }
+    }
+}
+
+impl From<UpdateCharacterDto> for UpdateModifications {
+    fn from(dto: UpdateCharacterDto) -> Self {
+        let mut doc = Document::new();
+
+        if let Some(mal_id) = dto.mal_id {
+            doc.insert(
+                "mal_id",
+                to_bson(&mal_id).expect("Failed to convert mal_id to bson"),
+            );
+        }
+        if let Some(url) = dto.url {
+            doc.insert("url", to_bson(&url).expect("Failed to convert url to bson"));
+        }
+        if let Some(images) = dto.images {
+            doc.insert(
+                "images",
+                to_bson(&images).expect("Failed to convert images to bson"),
+            );
+        }
+        if let Some(name) = dto.name {
+            doc.insert(
+                "name",
+                to_bson(&name).expect("Failed to convert name to bson"),
+            );
+        }
+        if let Some(name_kanji) = dto.name_kanji {
+            doc.insert(
+                "name_kanji",
+                to_bson(&name_kanji).expect("Failed to convert name_kanji to bson"),
+            );
+        }
+        if let Some(nicknames) = dto.nicknames {
+            doc.insert(
+                "nicknames",
+                to_bson(&nicknames).expect("Failed to convert nicknames to bson"),
+            );
+        }
+        if let Some(favorites) = dto.favorites {
+            doc.insert(
+                "favorites",
+                to_bson(&favorites).expect("Failed to convert favorites to bson"),
+            );
+        }
+        if let Some(about) = dto.about {
+            doc.insert(
+                "about",
+                to_bson(&about).expect("Failed to convert about to bson"),
+            );
+        }
+        if let Some(anime) = dto.anime {
+            doc.insert(
+                "anime",
+                to_bson(&anime).expect("Failed to convert anime to bson"),
+            );
+        }
+        if let Some(manga) = dto.manga {
+            doc.insert(
+                "manga",
+                to_bson(&manga).expect("Failed to convert manga to bson"),
+            );
+        }
+        if let Some(voices) = dto.voices {
+            doc.insert(
+                "voices",
+                to_bson(&voices).expect("Failed to convert voices to bson"),
+            );
+        }
+
+        UpdateModifications::Document(doc)
     }
 }
 

--- a/ponzu-back/src/dto/character.rs
+++ b/ponzu-back/src/dto/character.rs
@@ -1,3 +1,4 @@
+use crate::models::character::{Character, CharacterMedia, CharacterVoice};
 use crate::types::links::Images;
 use serde::{Deserialize, Serialize};
 
@@ -8,4 +9,142 @@ pub struct CharacterReference {
     pub url: String,
     pub images: Images,
     pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CharacterDto {
+    #[serde(
+        rename = "_id",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_hex_string_as_object_id",
+        deserialize_with = "deserialize_option_hex_string_from_object_id"
+    )]
+    pub id: Option<String>,
+    pub mal_id: u64,
+    pub url: String,
+    pub images: Images,
+    pub name: String,
+    pub name_kanji: String,
+    pub nicknames: Vec<String>,
+    pub favorites: u64,
+    pub about: String,
+    pub anime: Vec<CharacterMediaDto>,
+    pub manga: Vec<CharacterMediaDto>,
+    pub voices: Vec<CharacterVoiceDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CharacterMediaDto {
+    pub role: String,
+    pub media: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CharacterVoiceDto {
+    pub language: String,
+    pub person: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateCharacterDto {
+    pub mal_id: u64,
+    pub url: String,
+    pub images: Images,
+    pub name: String,
+    pub name_kanji: String,
+    pub nicknames: Vec<String>,
+    pub favorites: u64,
+    pub about: String,
+    pub anime: Vec<CharacterMediaDto>,
+    pub manga: Vec<CharacterMediaDto>,
+    pub voices: Vec<CharacterVoiceDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateCharacterDto {
+    pub mal_id: Option<u64>,
+    pub url: Option<String>,
+    pub images: Option<Images>,
+    pub name: Option<String>,
+    pub name_kanji: Option<String>,
+    pub nicknames: Option<Vec<String>>,
+    pub favorites: Option<u64>,
+    pub about: Option<String>,
+    pub anime: Option<Vec<CharacterMediaDto>>,
+    pub manga: Option<Vec<CharacterMediaDto>>,
+    pub voices: Option<Vec<CharacterVoiceDto>>,
+}
+
+impl From<Character> for CharacterDto {
+    fn from(character: Character) -> Self {
+        Self {
+            id: character.id,
+            mal_id: character.mal_id,
+            url: character.url,
+            images: character.images,
+            name: character.name,
+            name_kanji: character.name_kanji,
+            nicknames: character.nicknames,
+            favorites: character.favorites,
+            about: character.about,
+            anime: character.anime.into_iter().map(Into::into).collect(),
+            manga: character.manga.into_iter().map(Into::into).collect(),
+            voices: character.voices.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<CreateCharacterDto> for Character {
+    fn from(dto: CreateCharacterDto) -> Self {
+        Self {
+            id: None,
+            mal_id: dto.mal_id,
+            url: dto.url,
+            images: dto.images,
+            name: dto.name,
+            name_kanji: dto.name_kanji,
+            nicknames: dto.nicknames,
+            favorites: dto.favorites,
+            about: dto.about,
+            anime: dto.anime.into_iter().map(Into::into).collect(),
+            manga: dto.manga.into_iter().map(Into::into).collect(),
+            voices: dto.voices.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<CharacterMedia> for CharacterMediaDto {
+    fn from(media: CharacterMedia) -> Self {
+        Self {
+            role: media.role,
+            media: media.media,
+        }
+    }
+}
+
+impl From<CharacterMediaDto> for CharacterMedia {
+    fn from(dto: CharacterMediaDto) -> Self {
+        Self {
+            role: dto.role,
+            media: dto.media,
+        }
+    }
+}
+
+impl From<CharacterVoice> for CharacterVoiceDto {
+    fn from(voice: CharacterVoice) -> Self {
+        Self {
+            language: voice.language,
+            person: voice.person,
+        }
+    }
+}
+
+impl From<CharacterVoiceDto> for CharacterVoice {
+    fn from(dto: CharacterVoiceDto) -> Self {
+        Self {
+            language: dto.language,
+            person: dto.person,
+        }
+    }
 }

--- a/ponzu-back/src/dto/club.rs
+++ b/ponzu-back/src/dto/club.rs
@@ -1,4 +1,8 @@
 use crate::models::club::Club;
+use crate::utils::bson::{
+    deserialize_option_hex_string_from_object_id, serialize_option_hex_string_as_object_id,
+};
+use mongodb::bson::serde_helpers::serialize_bson_datetime_as_rfc3339_string;
 use mongodb::bson::DateTime;
 use serde::{Deserialize, Serialize};
 
@@ -16,15 +20,9 @@ pub struct ClubDto {
     pub members: Vec<String>,
     pub access: String,
     pub category: String,
-    #[serde(
-        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
-        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
-    )]
+    #[serde(serialize_with = "serialize_bson_datetime_as_rfc3339_string")]
     pub created_at: DateTime,
-    #[serde(
-        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
-        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
-    )]
+    #[serde(serialize_with = "serialize_bson_datetime_as_rfc3339_string")]
     pub updated_at: DateTime,
 }
 

--- a/ponzu-back/src/dto/club.rs
+++ b/ponzu-back/src/dto/club.rs
@@ -1,0 +1,78 @@
+use crate::models::club::Club;
+use mongodb::bson::DateTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ClubDto {
+    #[serde(
+        rename = "_id",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_hex_string_as_object_id",
+        deserialize_with = "deserialize_option_hex_string_from_object_id"
+    )]
+    pub id: Option<String>,
+    pub name: String,
+    pub description: Option<String>,
+    pub members: Vec<String>,
+    pub access: String,
+    pub category: String,
+    #[serde(
+        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
+        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
+    )]
+    pub created_at: DateTime,
+    #[serde(
+        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
+        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
+    )]
+    pub updated_at: DateTime,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateClubDto {
+    pub name: String,
+    pub description: Option<String>,
+    pub members: Vec<String>,
+    pub access: String,
+    pub category: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateClubDto {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub members: Option<Vec<String>>,
+    pub access: Option<String>,
+    pub category: Option<String>,
+}
+
+impl From<Club> for ClubDto {
+    fn from(club: Club) -> Self {
+        Self {
+            id: club.id,
+            name: club.name,
+            description: club.description,
+            members: club.members,
+            access: club.access,
+            category: club.category,
+            created_at: club.created_at,
+            updated_at: club.updated_at,
+        }
+    }
+}
+
+impl From<CreateClubDto> for Club {
+    fn from(dto: CreateClubDto) -> Self {
+        let now = DateTime::now();
+        Self {
+            id: None,
+            name: dto.name,
+            description: dto.description,
+            members: dto.members,
+            access: dto.access,
+            category: dto.category,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}

--- a/ponzu-back/src/dto/club.rs
+++ b/ponzu-back/src/dto/club.rs
@@ -6,6 +6,9 @@ use mongodb::bson::serde_helpers::serialize_bson_datetime_as_rfc3339_string;
 use mongodb::bson::DateTime;
 use serde::{Deserialize, Serialize};
 
+use mongodb::bson::{to_bson, Document};
+use mongodb::options::UpdateModifications;
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ClubDto {
     #[serde(
@@ -72,5 +75,44 @@ impl From<CreateClubDto> for Club {
             created_at: now,
             updated_at: now,
         }
+    }
+}
+
+impl From<UpdateClubDto> for UpdateModifications {
+    fn from(dto: UpdateClubDto) -> Self {
+        let mut doc = Document::new();
+
+        if let Some(name) = dto.name {
+            doc.insert(
+                "name",
+                to_bson(&name).expect("Failed to convert name to bson"),
+            );
+        }
+        if let Some(description) = dto.description {
+            doc.insert(
+                "description",
+                to_bson(&description).expect("Failed to convert description to bson"),
+            );
+        }
+        if let Some(members) = dto.members {
+            doc.insert(
+                "members",
+                to_bson(&members).expect("Failed to convert members to bson"),
+            );
+        }
+        if let Some(access) = dto.access {
+            doc.insert(
+                "access",
+                to_bson(&access).expect("Failed to convert access to bson"),
+            );
+        }
+        if let Some(category) = dto.category {
+            doc.insert(
+                "category",
+                to_bson(&category).expect("Failed to convert category to bson"),
+            );
+        }
+
+        UpdateModifications::Document(doc)
     }
 }

--- a/ponzu-back/src/dto/genre.rs
+++ b/ponzu-back/src/dto/genre.rs
@@ -1,4 +1,7 @@
 use crate::models::genre::Genre;
+use crate::utils::bson::{
+    deserialize_option_hex_string_from_object_id, serialize_option_hex_string_as_object_id,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/ponzu-back/src/dto/genre.rs
+++ b/ponzu-back/src/dto/genre.rs
@@ -2,6 +2,8 @@ use crate::models::genre::Genre;
 use crate::utils::bson::{
     deserialize_option_hex_string_from_object_id, serialize_option_hex_string_as_object_id,
 };
+use mongodb::bson::{to_bson, Document};
+use mongodb::options::UpdateModifications;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -56,5 +58,38 @@ impl From<CreateGenreDto> for Genre {
             name: dto.name,
             count: dto.count,
         }
+    }
+}
+
+impl From<UpdateGenreDto> for UpdateModifications {
+    fn from(dto: UpdateGenreDto) -> Self {
+        let mut doc = Document::new();
+
+        if let Some(mal_id) = dto.mal_id {
+            doc.insert(
+                "mal_id",
+                to_bson(&mal_id).expect("Failed to convert mal_id to bson"),
+            );
+        }
+        if let Some(r#type) = dto.r#type {
+            doc.insert(
+                "type",
+                to_bson(&r#type).expect("Failed to convert type to bson"),
+            );
+        }
+        if let Some(name) = dto.name {
+            doc.insert(
+                "name",
+                to_bson(&name).expect("Failed to convert name to bson"),
+            );
+        }
+        if let Some(count) = dto.count {
+            doc.insert(
+                "count",
+                to_bson(&count).expect("Failed to convert count to bson"),
+            );
+        }
+
+        UpdateModifications::Document(doc)
     }
 }

--- a/ponzu-back/src/dto/genre.rs
+++ b/ponzu-back/src/dto/genre.rs
@@ -1,0 +1,57 @@
+use crate::models::genre::Genre;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GenreDto {
+    #[serde(
+        rename = "_id",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_hex_string_as_object_id",
+        deserialize_with = "deserialize_option_hex_string_from_object_id"
+    )]
+    pub id: Option<String>,
+    pub mal_id: u64,
+    pub r#type: String,
+    pub name: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateGenreDto {
+    pub mal_id: u64,
+    pub r#type: String,
+    pub name: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateGenreDto {
+    pub mal_id: Option<u64>,
+    pub r#type: Option<String>,
+    pub name: Option<String>,
+    pub count: Option<u64>,
+}
+
+impl From<Genre> for GenreDto {
+    fn from(genre: Genre) -> Self {
+        Self {
+            id: genre.id,
+            mal_id: genre.mal_id,
+            r#type: genre.r#type,
+            name: genre.name,
+            count: genre.count,
+        }
+    }
+}
+
+impl From<CreateGenreDto> for Genre {
+    fn from(dto: CreateGenreDto) -> Self {
+        Self {
+            id: None,
+            mal_id: dto.mal_id,
+            r#type: dto.r#type,
+            name: dto.name,
+            count: dto.count,
+        }
+    }
+}

--- a/ponzu-back/src/dto/magazine.rs
+++ b/ponzu-back/src/dto/magazine.rs
@@ -1,0 +1,52 @@
+use crate::models::magazine::Magazine;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MagazineDto {
+    #[serde(
+        rename = "_id",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_hex_string_as_object_id",
+        deserialize_with = "deserialize_option_hex_string_from_object_id"
+    )]
+    pub id: Option<String>,
+    pub mal_id: u64,
+    pub name: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateMagazineDto {
+    pub mal_id: u64,
+    pub name: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateMagazineDto {
+    pub mal_id: Option<u64>,
+    pub name: Option<String>,
+    pub count: Option<u64>,
+}
+
+impl From<Magazine> for MagazineDto {
+    fn from(magazine: Magazine) -> Self {
+        Self {
+            id: magazine.id,
+            mal_id: magazine.mal_id,
+            name: magazine.name,
+            count: magazine.count,
+        }
+    }
+}
+
+impl From<CreateMagazineDto> for Magazine {
+    fn from(dto: CreateMagazineDto) -> Self {
+        Self {
+            id: None,
+            mal_id: dto.mal_id,
+            name: dto.name,
+            count: dto.count,
+        }
+    }
+}

--- a/ponzu-back/src/dto/magazine.rs
+++ b/ponzu-back/src/dto/magazine.rs
@@ -1,4 +1,7 @@
 use crate::models::magazine::Magazine;
+use crate::utils::bson::{
+    deserialize_option_hex_string_from_object_id, serialize_option_hex_string_as_object_id,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/ponzu-back/src/dto/magazine.rs
+++ b/ponzu-back/src/dto/magazine.rs
@@ -4,6 +4,9 @@ use crate::utils::bson::{
 };
 use serde::{Deserialize, Serialize};
 
+use mongodb::bson::{to_bson, Document};
+use mongodb::options::UpdateModifications;
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MagazineDto {
     #[serde(
@@ -51,5 +54,32 @@ impl From<CreateMagazineDto> for Magazine {
             name: dto.name,
             count: dto.count,
         }
+    }
+}
+
+impl From<UpdateMagazineDto> for UpdateModifications {
+    fn from(dto: UpdateMagazineDto) -> Self {
+        let mut doc = Document::new();
+
+        if let Some(mal_id) = dto.mal_id {
+            doc.insert(
+                "mal_id",
+                to_bson(&mal_id).expect("Failed to convert mal_id to bson"),
+            );
+        }
+        if let Some(name) = dto.name {
+            doc.insert(
+                "name",
+                to_bson(&name).expect("Failed to convert name to bson"),
+            );
+        }
+        if let Some(count) = dto.count {
+            doc.insert(
+                "count",
+                to_bson(&count).expect("Failed to convert count to bson"),
+            );
+        }
+
+        UpdateModifications::Document(doc)
     }
 }

--- a/ponzu-back/src/dto/manga.rs
+++ b/ponzu-back/src/dto/manga.rs
@@ -7,6 +7,8 @@ use crate::utils::bson::{
     serialize_option_hex_string_as_object_id,
 };
 use mongodb::bson::DateTime;
+use mongodb::bson::{to_bson, Document};
+use mongodb::options::UpdateModifications;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -205,6 +207,177 @@ impl From<CreateMangaDto> for Manga {
             relations: dto.relations,
             external: dto.external,
         }
+    }
+}
+
+impl From<UpdateMangaDto> for UpdateModifications {
+    fn from(dto: UpdateMangaDto) -> Self {
+        let mut doc = Document::new();
+
+        if let Some(mal_id) = dto.mal_id {
+            doc.insert(
+                "mal_id",
+                to_bson(&mal_id).expect("Failed to convert mal_id to bson"),
+            );
+        }
+        if let Some(images) = dto.images {
+            doc.insert(
+                "images",
+                to_bson(&images).expect("Failed to convert images to bson"),
+            );
+        }
+        if let Some(approved) = dto.approved {
+            doc.insert(
+                "approved",
+                to_bson(&approved).expect("Failed to convert approved to bson"),
+            );
+        }
+        if let Some(titles) = dto.titles {
+            doc.insert(
+                "titles",
+                to_bson(&titles).expect("Failed to convert titles to bson"),
+            );
+        }
+        if let Some(title) = dto.title {
+            doc.insert(
+                "title",
+                to_bson(&title).expect("Failed to convert title to bson"),
+            );
+        }
+        if let Some(title_english) = dto.title_english {
+            doc.insert(
+                "title_english",
+                to_bson(&title_english).expect("Failed to convert title_english to bson"),
+            );
+        }
+        if let Some(title_japanese) = dto.title_japanese {
+            doc.insert(
+                "title_japanese",
+                to_bson(&title_japanese).expect("Failed to convert title_japanese to bson"),
+            );
+        }
+        if let Some(title_synonyms) = dto.title_synonyms {
+            doc.insert(
+                "title_synonyms",
+                to_bson(&title_synonyms).expect("Failed to convert title_synonyms to bson"),
+            );
+        }
+        if let Some(r#type) = dto.r#type {
+            doc.insert(
+                "type",
+                to_bson(&r#type).expect("Failed to convert type to bson"),
+            );
+        }
+        if let Some(chapters) = dto.chapters {
+            doc.insert(
+                "chapters",
+                to_bson(&chapters).expect("Failed to convert chapters to bson"),
+            );
+        }
+        if let Some(volumes) = dto.volumes {
+            doc.insert(
+                "volumes",
+                to_bson(&volumes).expect("Failed to convert volumes to bson"),
+            );
+        }
+        if let Some(status) = dto.status {
+            doc.insert(
+                "status",
+                to_bson(&status).expect("Failed to convert status to bson"),
+            );
+        }
+        if let Some(publishing) = dto.publishing {
+            doc.insert(
+                "publishing",
+                to_bson(&publishing).expect("Failed to convert publishing to bson"),
+            );
+        }
+        if let Some(published) = dto.published {
+            doc.insert(
+                "published",
+                to_bson(&published).expect("Failed to convert published to bson"),
+            );
+        }
+        if let Some(scored_by) = dto.scored_by {
+            doc.insert(
+                "scored_by",
+                to_bson(&scored_by).expect("Failed to convert scored_by to bson"),
+            );
+        }
+        if let Some(members) = dto.members {
+            doc.insert(
+                "members",
+                to_bson(&members).expect("Failed to convert members to bson"),
+            );
+        }
+        if let Some(favorites) = dto.favorites {
+            doc.insert(
+                "favorites",
+                to_bson(&favorites).expect("Failed to convert favorites to bson"),
+            );
+        }
+        if let Some(synopsis) = dto.synopsis {
+            doc.insert(
+                "synopsis",
+                to_bson(&synopsis).expect("Failed to convert synopsis to bson"),
+            );
+        }
+        if let Some(background) = dto.background {
+            doc.insert(
+                "background",
+                to_bson(&background).expect("Failed to convert background to bson"),
+            );
+        }
+        if let Some(authors) = dto.authors {
+            doc.insert(
+                "authors",
+                to_bson(&authors).expect("Failed to convert authors to bson"),
+            );
+        }
+        if let Some(serializations) = dto.serializations {
+            doc.insert(
+                "serializations",
+                to_bson(&serializations).expect("Failed to convert serializations to bson"),
+            );
+        }
+        if let Some(genres) = dto.genres {
+            doc.insert(
+                "genres",
+                to_bson(&genres).expect("Failed to convert genres to bson"),
+            );
+        }
+        if let Some(explicit_genres) = dto.explicit_genres {
+            doc.insert(
+                "explicit_genres",
+                to_bson(&explicit_genres).expect("Failed to convert explicit_genres to bson"),
+            );
+        }
+        if let Some(themes) = dto.themes {
+            doc.insert(
+                "themes",
+                to_bson(&themes).expect("Failed to convert themes to bson"),
+            );
+        }
+        if let Some(demographics) = dto.demographics {
+            doc.insert(
+                "demographics",
+                to_bson(&demographics).expect("Failed to convert demographics to bson"),
+            );
+        }
+        if let Some(relations) = dto.relations {
+            doc.insert(
+                "relations",
+                to_bson(&relations).expect("Failed to convert relations to bson"),
+            );
+        }
+        if let Some(external) = dto.external {
+            doc.insert(
+                "external",
+                to_bson(&external).expect("Failed to convert external to bson"),
+            );
+        }
+
+        UpdateModifications::Document(doc)
     }
 }
 

--- a/ponzu-back/src/dto/manga.rs
+++ b/ponzu-back/src/dto/manga.rs
@@ -2,6 +2,10 @@ use crate::models::genre::Genre;
 use crate::models::manga::{Manga, Published, PublishedProp, PublishedPropFromTo};
 use crate::types::links::{ExternalLink, Images};
 use crate::types::title_meta::{MalEntity, Relation, Title};
+use crate::utils::bson::{
+    deserialize_option_hex_string_from_object_id, serialize_option_bson_datetime_as_rfc3339_string,
+    serialize_option_hex_string_as_object_id,
+};
 use mongodb::bson::DateTime;
 use serde::{Deserialize, Serialize};
 

--- a/ponzu-back/src/dto/manga.rs
+++ b/ponzu-back/src/dto/manga.rs
@@ -1,0 +1,265 @@
+use crate::models::genre::Genre;
+use crate::models::manga::{Manga, Published, PublishedProp, PublishedPropFromTo};
+use crate::types::links::{ExternalLink, Images};
+use crate::types::title_meta::{MalEntity, Relation, Title};
+use mongodb::bson::DateTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MangaDto {
+    #[serde(
+        rename = "_id",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_hex_string_as_object_id",
+        deserialize_with = "deserialize_option_hex_string_from_object_id"
+    )]
+    pub id: Option<String>,
+    pub mal_id: u64,
+    pub images: Images,
+    pub approved: bool,
+    pub titles: Vec<Title>,
+    pub title: String,
+    pub title_english: String,
+    pub title_japanese: String,
+    pub title_synonyms: Vec<String>,
+    pub r#type: String,
+    pub chapters: Option<u32>,
+    pub volumes: Option<u32>,
+    pub status: String,
+    pub publishing: bool,
+    pub published: PublishedDto,
+    pub scored_by: u64,
+    pub members: u64,
+    pub favorites: u64,
+    pub synopsis: String,
+    pub background: String,
+    pub authors: Vec<MalEntity>,
+    pub serializations: Vec<MalEntity>,
+    pub genres: Vec<Genre>,
+    pub explicit_genres: Vec<MalEntity>,
+    pub themes: Vec<MalEntity>,
+    pub demographics: Vec<MalEntity>,
+    pub relations: Vec<Relation>,
+    pub external: Vec<ExternalLink>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PublishedDto {
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_bson_datetime_as_rfc3339_string"
+    )]
+    pub from: Option<DateTime>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_bson_datetime_as_rfc3339_string"
+    )]
+    pub to: Option<DateTime>,
+    pub prop: PublishedPropDto,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PublishedPropDto {
+    pub from: PublishedPropFromToDto,
+    pub to: PublishedPropFromToDto,
+    pub string: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PublishedPropFromToDto {
+    pub day: i32,
+    pub month: i32,
+    pub year: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateMangaDto {
+    pub mal_id: u64,
+    pub images: Images,
+    pub approved: bool,
+    pub titles: Vec<Title>,
+    pub title: String,
+    pub title_english: String,
+    pub title_japanese: String,
+    pub title_synonyms: Vec<String>,
+    pub r#type: String,
+    pub chapters: Option<u32>,
+    pub volumes: Option<u32>,
+    pub status: String,
+    pub publishing: bool,
+    pub published: PublishedDto,
+    pub scored_by: u64,
+    pub members: u64,
+    pub favorites: u64,
+    pub synopsis: String,
+    pub background: String,
+    pub authors: Vec<MalEntity>,
+    pub serializations: Vec<MalEntity>,
+    pub genres: Vec<Genre>,
+    pub explicit_genres: Vec<MalEntity>,
+    pub themes: Vec<MalEntity>,
+    pub demographics: Vec<MalEntity>,
+    pub relations: Vec<Relation>,
+    pub external: Vec<ExternalLink>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateMangaDto {
+    pub mal_id: Option<u64>,
+    pub images: Option<Images>,
+    pub approved: Option<bool>,
+    pub titles: Option<Vec<Title>>,
+    pub title: Option<String>,
+    pub title_english: Option<String>,
+    pub title_japanese: Option<String>,
+    pub title_synonyms: Option<Vec<String>>,
+    pub r#type: Option<String>,
+    pub chapters: Option<u32>,
+    pub volumes: Option<u32>,
+    pub status: Option<String>,
+    pub publishing: Option<bool>,
+    pub published: Option<PublishedDto>,
+    pub scored_by: Option<u64>,
+    pub members: Option<u64>,
+    pub favorites: Option<u64>,
+    pub synopsis: Option<String>,
+    pub background: Option<String>,
+    pub authors: Option<Vec<MalEntity>>,
+    pub serializations: Option<Vec<MalEntity>>,
+    pub genres: Option<Vec<Genre>>,
+    pub explicit_genres: Option<Vec<MalEntity>>,
+    pub themes: Option<Vec<MalEntity>>,
+    pub demographics: Option<Vec<MalEntity>>,
+    pub relations: Option<Vec<Relation>>,
+    pub external: Option<Vec<ExternalLink>>,
+}
+
+impl From<Manga> for MangaDto {
+    fn from(manga: Manga) -> Self {
+        Self {
+            id: manga.id,
+            mal_id: manga.mal_id,
+            images: manga.images,
+            approved: manga.approved,
+            titles: manga.titles,
+            title: manga.title,
+            title_english: manga.title_english,
+            title_japanese: manga.title_japanese,
+            title_synonyms: manga.title_synonyms,
+            r#type: manga.r#type,
+            chapters: manga.chapters,
+            volumes: manga.volumes,
+            status: manga.status,
+            publishing: manga.publishing,
+            published: manga.published.into(),
+            scored_by: manga.scored_by,
+            members: manga.members,
+            favorites: manga.favorites,
+            synopsis: manga.synopsis,
+            background: manga.background,
+            authors: manga.authors,
+            serializations: manga.serializations,
+            genres: manga.genres,
+            explicit_genres: manga.explicit_genres,
+            themes: manga.themes,
+            demographics: manga.demographics,
+            relations: manga.relations,
+            external: manga.external,
+        }
+    }
+}
+
+impl From<CreateMangaDto> for Manga {
+    fn from(dto: CreateMangaDto) -> Self {
+        Self {
+            id: None,
+            mal_id: dto.mal_id,
+            images: dto.images,
+            approved: dto.approved,
+            titles: dto.titles,
+            title: dto.title,
+            title_english: dto.title_english,
+            title_japanese: dto.title_japanese,
+            title_synonyms: dto.title_synonyms,
+            r#type: dto.r#type,
+            chapters: dto.chapters,
+            volumes: dto.volumes,
+            status: dto.status,
+            publishing: dto.publishing,
+            published: dto.published.into(),
+            scored_by: dto.scored_by,
+            members: dto.members,
+            favorites: dto.favorites,
+            synopsis: dto.synopsis,
+            background: dto.background,
+            authors: dto.authors,
+            serializations: dto.serializations,
+            genres: dto.genres,
+            explicit_genres: dto.explicit_genres,
+            themes: dto.themes,
+            demographics: dto.demographics,
+            relations: dto.relations,
+            external: dto.external,
+        }
+    }
+}
+
+impl From<Published> for PublishedDto {
+    fn from(published: Published) -> Self {
+        Self {
+            from: published.from,
+            to: published.to,
+            prop: published.prop.into(),
+        }
+    }
+}
+
+impl From<PublishedDto> for Published {
+    fn from(dto: PublishedDto) -> Self {
+        Self {
+            from: dto.from,
+            to: dto.to,
+            prop: dto.prop.into(),
+        }
+    }
+}
+
+impl From<PublishedProp> for PublishedPropDto {
+    fn from(prop: PublishedProp) -> Self {
+        Self {
+            from: prop.from.into(),
+            to: prop.to.into(),
+            string: prop.string,
+        }
+    }
+}
+
+impl From<PublishedPropDto> for PublishedProp {
+    fn from(dto: PublishedPropDto) -> Self {
+        Self {
+            from: dto.from.into(),
+            to: dto.to.into(),
+            string: dto.string,
+        }
+    }
+}
+
+impl From<PublishedPropFromTo> for PublishedPropFromToDto {
+    fn from(prop: PublishedPropFromTo) -> Self {
+        Self {
+            day: prop.day,
+            month: prop.month,
+            year: prop.year,
+        }
+    }
+}
+
+impl From<PublishedPropFromToDto> for PublishedPropFromTo {
+    fn from(dto: PublishedPropFromToDto) -> Self {
+        Self {
+            day: dto.day,
+            month: dto.month,
+            year: dto.year,
+        }
+    }
+}

--- a/ponzu-back/src/dto/mod.rs
+++ b/ponzu-back/src/dto/mod.rs
@@ -1,4 +1,5 @@
 pub mod anime;
 pub mod character;
+pub mod club;
 pub mod entry;
 pub mod pagination;

--- a/ponzu-back/src/dto/mod.rs
+++ b/ponzu-back/src/dto/mod.rs
@@ -1,3 +1,4 @@
 pub mod entry;
 pub mod character;
 pub mod pagination;
+pub mod anime;

--- a/ponzu-back/src/dto/mod.rs
+++ b/ponzu-back/src/dto/mod.rs
@@ -8,3 +8,4 @@ pub mod manga;
 pub mod pagination;
 pub mod person;
 pub mod producer;
+pub mod review;

--- a/ponzu-back/src/dto/mod.rs
+++ b/ponzu-back/src/dto/mod.rs
@@ -3,4 +3,5 @@ pub mod character;
 pub mod club;
 pub mod entry;
 pub mod genre;
+pub mod magazine;
 pub mod pagination;

--- a/ponzu-back/src/dto/mod.rs
+++ b/ponzu-back/src/dto/mod.rs
@@ -9,3 +9,4 @@ pub mod pagination;
 pub mod person;
 pub mod producer;
 pub mod review;
+pub mod user;

--- a/ponzu-back/src/dto/mod.rs
+++ b/ponzu-back/src/dto/mod.rs
@@ -1,4 +1,4 @@
-pub mod entry;
-pub mod character;
-pub mod pagination;
 pub mod anime;
+pub mod character;
+pub mod entry;
+pub mod pagination;

--- a/ponzu-back/src/dto/mod.rs
+++ b/ponzu-back/src/dto/mod.rs
@@ -6,3 +6,4 @@ pub mod genre;
 pub mod magazine;
 pub mod manga;
 pub mod pagination;
+pub mod person;

--- a/ponzu-back/src/dto/mod.rs
+++ b/ponzu-back/src/dto/mod.rs
@@ -7,3 +7,4 @@ pub mod magazine;
 pub mod manga;
 pub mod pagination;
 pub mod person;
+pub mod producer;

--- a/ponzu-back/src/dto/mod.rs
+++ b/ponzu-back/src/dto/mod.rs
@@ -2,4 +2,5 @@ pub mod anime;
 pub mod character;
 pub mod club;
 pub mod entry;
+pub mod genre;
 pub mod pagination;

--- a/ponzu-back/src/dto/mod.rs
+++ b/ponzu-back/src/dto/mod.rs
@@ -4,4 +4,5 @@ pub mod club;
 pub mod entry;
 pub mod genre;
 pub mod magazine;
+pub mod manga;
 pub mod pagination;

--- a/ponzu-back/src/dto/person.rs
+++ b/ponzu-back/src/dto/person.rs
@@ -1,5 +1,10 @@
 use crate::models::person::{Person, PersonMedia, PersonVoice};
 use crate::types::links::Images;
+use crate::utils::bson::{
+    deserialize_option_hex_string_from_object_id, serialize_option_bson_datetime_as_rfc3339_string,
+    serialize_option_hex_string_as_object_id,
+};
+use mongodb::bson::serde_helpers::serialize_bson_datetime_as_rfc3339_string;
 use mongodb::bson::DateTime;
 use serde::{Deserialize, Serialize};
 
@@ -20,10 +25,7 @@ pub struct PersonDto {
     pub given_name: String,
     pub family_name: String,
     pub alternate_names: Vec<String>,
-    #[serde(
-        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
-        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
-    )]
+    #[serde(serialize_with = "serialize_bson_datetime_as_rfc3339_string")]
     pub birthday: DateTime,
     pub favorites: u64,
     pub about: String,
@@ -55,10 +57,7 @@ pub struct CreatePersonDto {
     pub given_name: String,
     pub family_name: String,
     pub alternate_names: Vec<String>,
-    #[serde(
-        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
-        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
-    )]
+    #[serde(serialize_with = "serialize_bson_datetime_as_rfc3339_string")]
     pub birthday: DateTime,
     pub favorites: u64,
     pub about: String,

--- a/ponzu-back/src/dto/person.rs
+++ b/ponzu-back/src/dto/person.rs
@@ -1,0 +1,172 @@
+use crate::models::person::{Person, PersonMedia, PersonVoice};
+use crate::types::links::Images;
+use mongodb::bson::DateTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PersonDto {
+    #[serde(
+        rename = "_id",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_hex_string_as_object_id",
+        deserialize_with = "deserialize_option_hex_string_from_object_id"
+    )]
+    pub id: Option<String>,
+    pub mal_id: u64,
+    pub url: String,
+    pub website_url: String,
+    pub images: Images,
+    pub name: String,
+    pub given_name: String,
+    pub family_name: String,
+    pub alternate_names: Vec<String>,
+    #[serde(
+        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
+        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
+    )]
+    pub birthday: DateTime,
+    pub favorites: u64,
+    pub about: String,
+    pub anime: Vec<PersonMediaDto>,
+    pub manga: Vec<PersonMediaDto>,
+    pub voices: Vec<PersonVoiceDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PersonMediaDto {
+    pub position: String,
+    pub media: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PersonVoiceDto {
+    pub role: String,
+    pub anime: String,
+    pub character: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreatePersonDto {
+    pub mal_id: u64,
+    pub url: String,
+    pub website_url: String,
+    pub images: Images,
+    pub name: String,
+    pub given_name: String,
+    pub family_name: String,
+    pub alternate_names: Vec<String>,
+    #[serde(
+        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
+        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
+    )]
+    pub birthday: DateTime,
+    pub favorites: u64,
+    pub about: String,
+    pub anime: Vec<PersonMediaDto>,
+    pub manga: Vec<PersonMediaDto>,
+    pub voices: Vec<PersonVoiceDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdatePersonDto {
+    pub mal_id: Option<u64>,
+    pub url: Option<String>,
+    pub website_url: Option<String>,
+    pub images: Option<Images>,
+    pub name: Option<String>,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
+    pub alternate_names: Option<Vec<String>>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_bson_datetime_as_rfc3339_string"
+    )]
+    pub birthday: Option<DateTime>,
+    pub favorites: Option<u64>,
+    pub about: Option<String>,
+    pub anime: Option<Vec<PersonMediaDto>>,
+    pub manga: Option<Vec<PersonMediaDto>>,
+    pub voices: Option<Vec<PersonVoiceDto>>,
+}
+
+impl From<Person> for PersonDto {
+    fn from(person: Person) -> Self {
+        Self {
+            id: person.id,
+            mal_id: person.mal_id,
+            url: person.url,
+            website_url: person.website_url,
+            images: person.images,
+            name: person.name,
+            given_name: person.given_name,
+            family_name: person.family_name,
+            alternate_names: person.alternate_names,
+            birthday: person.birthday,
+            favorites: person.favorites,
+            about: person.about,
+            anime: person.anime.into_iter().map(Into::into).collect(),
+            manga: person.manga.into_iter().map(Into::into).collect(),
+            voices: person.voices.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<CreatePersonDto> for Person {
+    fn from(dto: CreatePersonDto) -> Self {
+        Self {
+            id: None,
+            mal_id: dto.mal_id,
+            url: dto.url,
+            website_url: dto.website_url,
+            images: dto.images,
+            name: dto.name,
+            given_name: dto.given_name,
+            family_name: dto.family_name,
+            alternate_names: dto.alternate_names,
+            birthday: dto.birthday,
+            favorites: dto.favorites,
+            about: dto.about,
+            anime: dto.anime.into_iter().map(Into::into).collect(),
+            manga: dto.manga.into_iter().map(Into::into).collect(),
+            voices: dto.voices.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<PersonMedia> for PersonMediaDto {
+    fn from(media: PersonMedia) -> Self {
+        Self {
+            position: media.position,
+            media: media.media,
+        }
+    }
+}
+
+impl From<PersonMediaDto> for PersonMedia {
+    fn from(dto: PersonMediaDto) -> Self {
+        Self {
+            position: dto.position,
+            media: dto.media,
+        }
+    }
+}
+
+impl From<PersonVoice> for PersonVoiceDto {
+    fn from(voice: PersonVoice) -> Self {
+        Self {
+            role: voice.role,
+            anime: voice.anime,
+            character: voice.character,
+        }
+    }
+}
+
+impl From<PersonVoiceDto> for PersonVoice {
+    fn from(dto: PersonVoiceDto) -> Self {
+        Self {
+            role: dto.role,
+            anime: dto.anime,
+            character: dto.character,
+        }
+    }
+}

--- a/ponzu-back/src/dto/person.rs
+++ b/ponzu-back/src/dto/person.rs
@@ -6,6 +6,8 @@ use crate::utils::bson::{
 };
 use mongodb::bson::serde_helpers::serialize_bson_datetime_as_rfc3339_string;
 use mongodb::bson::DateTime;
+use mongodb::bson::{to_bson, Document};
+use mongodb::options::UpdateModifications;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -129,6 +131,96 @@ impl From<CreatePersonDto> for Person {
             manga: dto.manga.into_iter().map(Into::into).collect(),
             voices: dto.voices.into_iter().map(Into::into).collect(),
         }
+    }
+}
+
+impl From<UpdatePersonDto> for UpdateModifications {
+    fn from(dto: UpdatePersonDto) -> Self {
+        let mut doc = Document::new();
+
+        if let Some(mal_id) = dto.mal_id {
+            doc.insert(
+                "mal_id",
+                to_bson(&mal_id).expect("Failed to convert mal_id to bson"),
+            );
+        }
+        if let Some(url) = dto.url {
+            doc.insert("url", to_bson(&url).expect("Failed to convert url to bson"));
+        }
+        if let Some(website_url) = dto.website_url {
+            doc.insert(
+                "website_url",
+                to_bson(&website_url).expect("Failed to convert website_url to bson"),
+            );
+        }
+        if let Some(images) = dto.images {
+            doc.insert(
+                "images",
+                to_bson(&images).expect("Failed to convert images to bson"),
+            );
+        }
+        if let Some(name) = dto.name {
+            doc.insert(
+                "name",
+                to_bson(&name).expect("Failed to convert name to bson"),
+            );
+        }
+        if let Some(given_name) = dto.given_name {
+            doc.insert(
+                "given_name",
+                to_bson(&given_name).expect("Failed to convert given_name to bson"),
+            );
+        }
+        if let Some(family_name) = dto.family_name {
+            doc.insert(
+                "family_name",
+                to_bson(&family_name).expect("Failed to convert family_name to bson"),
+            );
+        }
+        if let Some(alternate_names) = dto.alternate_names {
+            doc.insert(
+                "alternate_names",
+                to_bson(&alternate_names).expect("Failed to convert alternate_names to bson"),
+            );
+        }
+        if let Some(birthday) = dto.birthday {
+            doc.insert(
+                "birthday",
+                to_bson(&birthday).expect("Failed to convert birthday to bson"),
+            );
+        }
+        if let Some(favorites) = dto.favorites {
+            doc.insert(
+                "favorites",
+                to_bson(&favorites).expect("Failed to convert favorites to bson"),
+            );
+        }
+        if let Some(about) = dto.about {
+            doc.insert(
+                "about",
+                to_bson(&about).expect("Failed to convert about to bson"),
+            );
+        }
+        if let Some(anime) = dto.anime {
+            doc.insert(
+                "anime",
+                to_bson(&anime).expect("Failed to convert anime to bson"),
+            );
+        }
+        if let Some(manga) = dto.manga {
+            doc.insert(
+                "manga",
+                to_bson(&manga).expect("Failed to convert manga to bson"),
+            );
+        }
+        if let Some(voices) = dto.voices {
+            doc.insert(
+                "voices",
+                to_bson(&voices).expect("Failed to convert voices to bson"),
+            );
+        }
+
+        UpdateModifications::Document(doc)
     }
 }
 

--- a/ponzu-back/src/dto/producer.rs
+++ b/ponzu-back/src/dto/producer.rs
@@ -1,0 +1,85 @@
+use crate::models::producer::Producer;
+use crate::types::links::{ExternalLink, Images};
+use crate::types::title_meta::MalEntity;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ProducerDto {
+    pub mal_id: u64,
+    pub titles: Vec<MalEntity>,
+    pub images: Option<Images>,
+    pub favorites: u64,
+    pub count: u64,
+    pub established: String,
+    pub about: String,
+    pub external: Vec<ExternalLink>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateProducerDto {
+    pub mal_id: u64,
+    pub titles: Vec<MalEntity>,
+    pub images: Option<Images>,
+    pub favorites: u64,
+    pub count: u64,
+    pub established: String,
+    pub about: String,
+    pub external: Vec<ExternalLink>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateProducerDto {
+    pub mal_id: Option<u64>,
+    pub titles: Option<Vec<MalEntity>>,
+    pub images: Option<Images>,
+    pub favorites: Option<u64>,
+    pub count: Option<u64>,
+    pub established: Option<String>,
+    pub about: Option<String>,
+    pub external: Option<Vec<ExternalLink>>,
+}
+
+impl From<Producer> for ProducerDto {
+    fn from(producer: Producer) -> Self {
+        Self {
+            mal_id: producer.mal_id,
+            titles: producer.titles,
+            images: producer.images,
+            favorites: producer.favorites,
+            count: producer.count,
+            established: producer.established,
+            about: producer.about,
+            external: producer.external,
+        }
+    }
+}
+
+impl From<ProducerDto> for Producer {
+    fn from(dto: ProducerDto) -> Self {
+        Self {
+            mal_id: dto.mal_id,
+            titles: dto.titles,
+            images: dto.images,
+            favorites: dto.favorites,
+            count: dto.count,
+            established: dto.established,
+            about: dto.about,
+            external: dto.external,
+        }
+    }
+}
+
+impl From<CreateProducerDto> for Producer {
+    fn from(dto: CreateProducerDto) -> Self {
+        Self {
+            mal_id: dto.mal_id,
+            titles: dto.titles,
+            images: dto.images,
+            favorites: dto.favorites,
+            count: dto.count,
+            established: dto.established,
+            about: dto.about,
+            external: dto.external,
+        }
+    }
+}

--- a/ponzu-back/src/dto/producer.rs
+++ b/ponzu-back/src/dto/producer.rs
@@ -1,6 +1,8 @@
 use crate::models::producer::Producer;
 use crate::types::links::{ExternalLink, Images};
 use crate::types::title_meta::MalEntity;
+use mongodb::bson::{to_bson, Document};
+use mongodb::options::UpdateModifications;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -81,5 +83,62 @@ impl From<CreateProducerDto> for Producer {
             about: dto.about,
             external: dto.external,
         }
+    }
+}
+
+impl From<UpdateProducerDto> for UpdateModifications {
+    fn from(dto: UpdateProducerDto) -> Self {
+        let mut doc = Document::new();
+
+        if let Some(mal_id) = dto.mal_id {
+            doc.insert(
+                "mal_id",
+                to_bson(&mal_id).expect("Failed to convert mal_id to bson"),
+            );
+        }
+        if let Some(titles) = dto.titles {
+            doc.insert(
+                "titles",
+                to_bson(&titles).expect("Failed to convert titles to bson"),
+            );
+        }
+        if let Some(images) = dto.images {
+            doc.insert(
+                "images",
+                to_bson(&images).expect("Failed to convert images to bson"),
+            );
+        }
+        if let Some(favorites) = dto.favorites {
+            doc.insert(
+                "favorites",
+                to_bson(&favorites).expect("Failed to convert favorites to bson"),
+            );
+        }
+        if let Some(count) = dto.count {
+            doc.insert(
+                "count",
+                to_bson(&count).expect("Failed to convert count to bson"),
+            );
+        }
+        if let Some(established) = dto.established {
+            doc.insert(
+                "established",
+                to_bson(&established).expect("Failed to convert established to bson"),
+            );
+        }
+        if let Some(about) = dto.about {
+            doc.insert(
+                "about",
+                to_bson(&about).expect("Failed to convert about to bson"),
+            );
+        }
+        if let Some(external) = dto.external {
+            doc.insert(
+                "external",
+                to_bson(&external).expect("Failed to convert external to bson"),
+            );
+        }
+
+        UpdateModifications::Document(doc)
     }
 }

--- a/ponzu-back/src/dto/review.rs
+++ b/ponzu-back/src/dto/review.rs
@@ -1,0 +1,180 @@
+use crate::models::review::{Reactions, Review};
+use mongodb::bson::DateTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReviewDto {
+    #[serde(
+        rename = "_id",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_hex_string_as_object_id",
+        deserialize_with = "deserialize_option_hex_string_from_object_id"
+    )]
+    pub id: Option<String>,
+    pub mal_id: u64,
+    pub url: String,
+    pub r#type: String,
+    pub reactions: ReactionsDto,
+    #[serde(
+        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
+        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
+    )]
+    pub date: DateTime,
+    pub review: String,
+    pub score: u8,
+    pub tags: Vec<String>,
+    pub is_spoiler: bool,
+    pub is_preliminary: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub episodes_watched: Option<u64>,
+    pub entry: String,
+    pub user: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReactionsDto {
+    pub overall: u64,
+    pub nice: u64,
+    pub love_it: u64,
+    pub funny: u64,
+    pub confusing: u64,
+    pub informative: u64,
+    pub well_written: u64,
+    pub creative: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateReviewDto {
+    pub mal_id: u64,
+    pub url: String,
+    pub r#type: String,
+    pub reactions: ReactionsDto,
+    #[serde(
+        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
+        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
+    )]
+    pub date: DateTime,
+    pub review: String,
+    pub score: u8,
+    pub tags: Vec<String>,
+    pub is_spoiler: bool,
+    pub is_preliminary: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub episodes_watched: Option<u64>,
+    pub entry: String,
+    pub user: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateReviewDto {
+    pub mal_id: Option<u64>,
+    pub url: Option<String>,
+    pub r#type: Option<String>,
+    pub reactions: Option<ReactionsDto>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_bson_datetime_as_rfc3339_string"
+    )]
+    pub date: Option<DateTime>,
+    pub review: Option<String>,
+    pub score: Option<u8>,
+    pub tags: Option<Vec<String>>,
+    pub is_spoiler: Option<bool>,
+    pub is_preliminary: Option<bool>,
+    pub episodes_watched: Option<u64>,
+    pub entry: Option<String>,
+    pub user: Option<String>,
+}
+
+impl From<Review> for ReviewDto {
+    fn from(review: Review) -> Self {
+        Self {
+            id: review.id,
+            mal_id: review.mal_id,
+            url: review.url,
+            r#type: review.r#type,
+            reactions: review.reactions.into(),
+            date: review.date,
+            review: review.review,
+            score: review.score,
+            tags: review.tags,
+            is_spoiler: review.is_spoiler,
+            is_preliminary: review.is_preliminary,
+            episodes_watched: review.episodes_watched,
+            entry: review.entry,
+            user: review.user,
+        }
+    }
+}
+
+impl From<ReviewDto> for Review {
+    fn from(dto: ReviewDto) -> Self {
+        Self {
+            id: dto.id,
+            mal_id: dto.mal_id,
+            url: dto.url,
+            r#type: dto.r#type,
+            reactions: dto.reactions.into(),
+            date: dto.date,
+            review: dto.review,
+            score: dto.score,
+            tags: dto.tags,
+            is_spoiler: dto.is_spoiler,
+            is_preliminary: dto.is_preliminary,
+            episodes_watched: dto.episodes_watched,
+            entry: dto.entry,
+            user: dto.user,
+        }
+    }
+}
+
+impl From<CreateReviewDto> for Review {
+    fn from(dto: CreateReviewDto) -> Self {
+        Self {
+            id: None,
+            mal_id: dto.mal_id,
+            url: dto.url,
+            r#type: dto.r#type,
+            reactions: dto.reactions.into(),
+            date: dto.date,
+            review: dto.review,
+            score: dto.score,
+            tags: dto.tags,
+            is_spoiler: dto.is_spoiler,
+            is_preliminary: dto.is_preliminary,
+            episodes_watched: dto.episodes_watched,
+            entry: dto.entry,
+            user: dto.user,
+        }
+    }
+}
+
+impl From<Reactions> for ReactionsDto {
+    fn from(reactions: Reactions) -> Self {
+        Self {
+            overall: reactions.overall,
+            nice: reactions.nice,
+            love_it: reactions.love_it,
+            funny: reactions.funny,
+            confusing: reactions.confusing,
+            informative: reactions.informative,
+            well_written: reactions.well_written,
+            creative: reactions.creative,
+        }
+    }
+}
+
+impl From<ReactionsDto> for Reactions {
+    fn from(dto: ReactionsDto) -> Self {
+        Self {
+            overall: dto.overall,
+            nice: dto.nice,
+            love_it: dto.love_it,
+            funny: dto.funny,
+            confusing: dto.confusing,
+            informative: dto.informative,
+            well_written: dto.well_written,
+            creative: dto.creative,
+        }
+    }
+}

--- a/ponzu-back/src/dto/review.rs
+++ b/ponzu-back/src/dto/review.rs
@@ -5,6 +5,8 @@ use crate::utils::bson::{
 };
 use mongodb::bson::serde_helpers::serialize_bson_datetime_as_rfc3339_string;
 use mongodb::bson::DateTime;
+use mongodb::bson::{to_bson, Document};
+use mongodb::options::UpdateModifications;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -145,6 +147,90 @@ impl From<CreateReviewDto> for Review {
             entry: dto.entry,
             user: dto.user,
         }
+    }
+}
+
+impl From<UpdateReviewDto> for UpdateModifications {
+    fn from(dto: UpdateReviewDto) -> Self {
+        let mut doc = Document::new();
+
+        if let Some(mal_id) = dto.mal_id {
+            doc.insert(
+                "mal_id",
+                to_bson(&mal_id).expect("Failed to convert mal_id to bson"),
+            );
+        }
+        if let Some(url) = dto.url {
+            doc.insert("url", to_bson(&url).expect("Failed to convert url to bson"));
+        }
+        if let Some(r#type) = dto.r#type {
+            doc.insert(
+                "type",
+                to_bson(&r#type).expect("Failed to convert type to bson"),
+            );
+        }
+        if let Some(reactions) = dto.reactions {
+            doc.insert(
+                "reactions",
+                to_bson(&reactions).expect("Failed to convert reactions to bson"),
+            );
+        }
+        if let Some(date) = dto.date {
+            doc.insert(
+                "date",
+                to_bson(&date).expect("Failed to convert date to bson"),
+            );
+        }
+        if let Some(review) = dto.review {
+            doc.insert(
+                "review",
+                to_bson(&review).expect("Failed to convert review to bson"),
+            );
+        }
+        if let Some(score) = dto.score {
+            doc.insert(
+                "score",
+                to_bson(&score).expect("Failed to convert score to bson"),
+            );
+        }
+        if let Some(tags) = dto.tags {
+            doc.insert(
+                "tags",
+                to_bson(&tags).expect("Failed to convert tags to bson"),
+            );
+        }
+        if let Some(is_spoiler) = dto.is_spoiler {
+            doc.insert(
+                "is_spoiler",
+                to_bson(&is_spoiler).expect("Failed to convert is_spoiler to bson"),
+            );
+        }
+        if let Some(is_preliminary) = dto.is_preliminary {
+            doc.insert(
+                "is_preliminary",
+                to_bson(&is_preliminary).expect("Failed to convert is_preliminary to bson"),
+            );
+        }
+        if let Some(episodes_watched) = dto.episodes_watched {
+            doc.insert(
+                "episodes_watched",
+                to_bson(&episodes_watched).expect("Failed to convert episodes_watched to bson"),
+            );
+        }
+        if let Some(entry) = dto.entry {
+            doc.insert(
+                "entry",
+                to_bson(&entry).expect("Failed to convert entry to bson"),
+            );
+        }
+        if let Some(user) = dto.user {
+            doc.insert(
+                "user",
+                to_bson(&user).expect("Failed to convert user to bson"),
+            );
+        }
+
+        UpdateModifications::Document(doc)
     }
 }
 

--- a/ponzu-back/src/dto/review.rs
+++ b/ponzu-back/src/dto/review.rs
@@ -1,4 +1,9 @@
 use crate::models::review::{Reactions, Review};
+use crate::utils::bson::{
+    deserialize_option_hex_string_from_object_id, serialize_option_bson_datetime_as_rfc3339_string,
+    serialize_option_hex_string_as_object_id,
+};
+use mongodb::bson::serde_helpers::serialize_bson_datetime_as_rfc3339_string;
 use mongodb::bson::DateTime;
 use serde::{Deserialize, Serialize};
 
@@ -15,10 +20,7 @@ pub struct ReviewDto {
     pub url: String,
     pub r#type: String,
     pub reactions: ReactionsDto,
-    #[serde(
-        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
-        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
-    )]
+    #[serde(serialize_with = "serialize_bson_datetime_as_rfc3339_string")]
     pub date: DateTime,
     pub review: String,
     pub score: u8,
@@ -49,10 +51,7 @@ pub struct CreateReviewDto {
     pub url: String,
     pub r#type: String,
     pub reactions: ReactionsDto,
-    #[serde(
-        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
-        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
-    )]
+    #[serde(serialize_with = "serialize_bson_datetime_as_rfc3339_string")]
     pub date: DateTime,
     pub review: String,
     pub score: u8,

--- a/ponzu-back/src/dto/user.rs
+++ b/ponzu-back/src/dto/user.rs
@@ -5,6 +5,8 @@ use crate::utils::bson::{
 };
 use mongodb::bson::serde_helpers::serialize_bson_datetime_as_rfc3339_string;
 use mongodb::bson::DateTime;
+use mongodb::bson::{to_bson, Document};
+use mongodb::options::UpdateModifications;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -131,5 +133,65 @@ impl From<RegisterUserDto> for User {
             updated_at: DateTime::now(),
             last_online: DateTime::now(),
         }
+    }
+}
+
+impl From<UpdateUserDto> for UpdateModifications {
+    fn from(dto: UpdateUserDto) -> Self {
+        let mut doc = Document::new();
+
+        if let Some(username) = dto.username {
+            doc.insert(
+                "username",
+                to_bson(&username).expect("Failed to convert username to bson"),
+            );
+        }
+        if let Some(email) = dto.email {
+            doc.insert(
+                "email",
+                to_bson(&email).expect("Failed to convert email to bson"),
+            );
+        }
+        if let Some(password) = dto.password {
+            doc.insert(
+                "password",
+                to_bson(&password).expect("Failed to convert password to bson"),
+            );
+        }
+        if let Some(is_active) = dto.is_active {
+            doc.insert(
+                "is_active",
+                to_bson(&is_active).expect("Failed to convert is_active to bson"),
+            );
+        }
+        if let Some(is_staff) = dto.is_staff {
+            doc.insert(
+                "is_staff",
+                to_bson(&is_staff).expect("Failed to convert is_staff to bson"),
+            );
+        }
+        if let Some(is_superuser) = dto.is_superuser {
+            doc.insert(
+                "is_superuser",
+                to_bson(&is_superuser).expect("Failed to convert is_superuser to bson"),
+            );
+        }
+        if let Some(images) = dto.images {
+            doc.insert(
+                "images",
+                to_bson(&images).expect("Failed to convert images to bson"),
+            );
+        }
+        if let Some(bio) = dto.bio {
+            doc.insert("bio", to_bson(&bio).expect("Failed to convert bio to bson"));
+        }
+        if let Some(birth_date) = dto.birth_date {
+            doc.insert(
+                "birth_date",
+                to_bson(&birth_date).expect("Failed to convert birth_date to bson"),
+            );
+        }
+
+        UpdateModifications::Document(doc)
     }
 }

--- a/ponzu-back/src/dto/user.rs
+++ b/ponzu-back/src/dto/user.rs
@@ -1,4 +1,9 @@
 use crate::models::user::User;
+use crate::utils::bson::{
+    deserialize_option_hex_string_from_object_id, serialize_option_bson_datetime_as_rfc3339_string,
+    serialize_option_hex_string_as_object_id,
+};
+use mongodb::bson::serde_helpers::serialize_bson_datetime_as_rfc3339_string;
 use mongodb::bson::DateTime;
 use serde::{Deserialize, Serialize};
 
@@ -24,20 +29,11 @@ pub struct UserDto {
         serialize_with = "serialize_option_bson_datetime_as_rfc3339_string"
     )]
     pub birth_date: Option<DateTime>,
-    #[serde(
-        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
-        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
-    )]
+    #[serde(serialize_with = "serialize_bson_datetime_as_rfc3339_string")]
     pub created_at: DateTime,
-    #[serde(
-        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
-        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
-    )]
+    #[serde(serialize_with = "serialize_bson_datetime_as_rfc3339_string")]
     pub updated_at: DateTime,
-    #[serde(
-        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
-        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
-    )]
+    #[serde(serialize_with = "serialize_bson_datetime_as_rfc3339_string")]
     pub last_online: DateTime,
 }
 

--- a/ponzu-back/src/dto/user.rs
+++ b/ponzu-back/src/dto/user.rs
@@ -1,0 +1,139 @@
+use crate::models::user::User;
+use mongodb::bson::DateTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UserDto {
+    #[serde(
+        rename = "_id",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_hex_string_as_object_id",
+        deserialize_with = "deserialize_option_hex_string_from_object_id"
+    )]
+    pub id: Option<String>,
+    pub username: String,
+    pub email: String,
+    pub password: String,
+    pub is_active: bool,
+    pub is_staff: bool,
+    pub is_superuser: bool,
+    pub images: Option<String>,
+    pub bio: Option<String>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_bson_datetime_as_rfc3339_string"
+    )]
+    pub birth_date: Option<DateTime>,
+    #[serde(
+        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
+        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
+    )]
+    pub created_at: DateTime,
+    #[serde(
+        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
+        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
+    )]
+    pub updated_at: DateTime,
+    #[serde(
+        serialize_with = "serialize_bson_datetime_as_rfc3339_string",
+        deserialize_with = "deserialize_bson_datetime_from_rfc3339_string"
+    )]
+    pub last_online: DateTime,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RegisterUserDto {
+    pub username: String,
+    pub email: String,
+    pub password: String,
+    pub images: Option<String>,
+    pub bio: Option<String>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_bson_datetime_as_rfc3339_string"
+    )]
+    pub birth_date: Option<DateTime>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateUserDto {
+    pub username: Option<String>,
+    pub email: Option<String>,
+    pub password: Option<String>,
+    pub is_active: Option<bool>,
+    pub is_staff: Option<bool>,
+    pub is_superuser: Option<bool>,
+    pub images: Option<String>,
+    pub bio: Option<String>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_bson_datetime_as_rfc3339_string"
+    )]
+    pub birth_date: Option<DateTime>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LoginDto {
+    pub username: String,
+    pub password: String,
+}
+
+impl From<User> for UserDto {
+    fn from(user: User) -> Self {
+        Self {
+            id: user.id,
+            username: user.username,
+            email: user.email,
+            password: user.password,
+            is_active: user.is_active,
+            is_staff: user.is_staff,
+            is_superuser: user.is_superuser,
+            images: user.images,
+            bio: user.bio,
+            birth_date: user.birth_date,
+            created_at: user.created_at,
+            updated_at: user.updated_at,
+            last_online: user.last_online,
+        }
+    }
+}
+
+impl From<UserDto> for User {
+    fn from(dto: UserDto) -> Self {
+        Self {
+            id: dto.id,
+            username: dto.username,
+            email: dto.email,
+            password: dto.password,
+            is_active: dto.is_active,
+            is_staff: dto.is_staff,
+            is_superuser: dto.is_superuser,
+            images: dto.images,
+            bio: dto.bio,
+            birth_date: dto.birth_date,
+            created_at: dto.created_at,
+            updated_at: dto.updated_at,
+            last_online: dto.last_online,
+        }
+    }
+}
+
+impl From<RegisterUserDto> for User {
+    fn from(dto: RegisterUserDto) -> Self {
+        Self {
+            id: None,
+            username: dto.username,
+            email: dto.email,
+            password: dto.password,
+            is_active: false,
+            is_staff: false,
+            is_superuser: false,
+            images: dto.images,
+            bio: dto.bio,
+            birth_date: dto.birth_date,
+            created_at: DateTime::now(),
+            updated_at: DateTime::now(),
+            last_online: DateTime::now(),
+        }
+    }
+}

--- a/ponzu-back/src/endpoints/anime/title.rs
+++ b/ponzu-back/src/endpoints/anime/title.rs
@@ -1,43 +1,38 @@
-use crate::models::app_error::AppError;
-use crate::models::app_state::AppState;
-use crate::models::title::Anime;
-use actix_web::web::{scope, Data, Form, Path};
-use actix_web::{delete, get, post, HttpResponse, Responder};
-use mongodb::bson::doc;
+use actix_web::web::{scope};
 
 pub fn create_anime_scope() -> actix_web::Scope {
     scope("/anime")
-        .service(get_all_anime_titles)
-        .service(get_anime_title)
+        // .service(get_all_anime_titles)
+        // .service(get_anime_title)
 }
 
-#[get("")]
-pub async fn get_all_anime_titles(data: Data<AppState>) -> impl Responder {
-    match data.anime_service.find(None, None).await {
-        Ok(anime) => Ok(HttpResponse::Ok().json(anime)),
-        Err(e) => Err(e),
-    }
-}
+// #[get("")]
+// pub async fn get_all_anime_titles(data: Data<AppState>) -> impl Responder {
+//     match data.anime_service.find(None, None).await {
+//         Ok(anime) => Ok(HttpResponse::Ok().json(anime)),
+//         Err(e) => Err(e),
+//     }
+// }
 
-#[get("{id}")]
-pub async fn get_anime_title(path: Path<String>, data: Data<AppState>) -> impl Responder {
-    let id = path.into_inner();
-    match data.anime_service.find_one(doc! {"_id": id.as_str()}).await {
-        Ok(anime) => match anime {
-            Some(a) => Ok(HttpResponse::Ok().json(a)),
-            None => Err(AppError::NotFound("Anime not found".to_string())),
-        },
-        Err(e) => Err(e),
-    }
-}
+// #[get("{id}")]
+// pub async fn get_anime_title(path: Path<String>, data: Data<AppState>) -> impl Responder {
+//     let id = path.into_inner();
+//     match data.anime_service.find_one(doc! {"_id": id.as_str()}).await {
+//         Ok(anime) => match anime {
+//             Some(a) => Ok(HttpResponse::Ok().json(a)),
+//             None => Err(AppError::NotFound("Anime not found".to_string())),
+//         },
+//         Err(e) => Err(e),
+//     }
+// }
 
-#[post("")]
-pub async fn create_anime_title(form: Form<Anime>, data: Data<AppState>) -> impl Responder {
-    match data.anime_service.insert_one(form.into_inner()).await {
-        Ok(anime) => Ok(HttpResponse::Created().json(anime)),
-        Err(e) => Err(e),
-    }
-}
+// #[post("")]
+// pub async fn create_anime_title(form: Form<Anime>, data: Data<AppState>) -> impl Responder {
+//     match data.anime_service.insert_one(form.into_inner()).await {
+//         Ok(anime) => Ok(HttpResponse::Created().json(anime)),
+//         Err(e) => Err(e),
+//     }
+// }
 
 // #[patch("{id}")]
 // pub async fn update_anime_title(
@@ -52,15 +47,15 @@ pub async fn create_anime_title(form: Form<Anime>, data: Data<AppState>) -> impl
 //     }
 // }
 
-#[delete("{id}")]
-pub async fn delete_anime_title(path: Path<String>, data: Data<AppState>) -> impl Responder {
-    let id = path.into_inner();
-    match data
-        .anime_service
-        .delete_one(doc! {"_id": id.as_str()})
-        .await
-    {
-        Ok(_) => Ok(HttpResponse::NoContent().finish()),
-        Err(e) => Err(e),
-    }
-}
+// #[delete("{id}")]
+// pub async fn delete_anime_title(path: Path<String>, data: Data<AppState>) -> impl Responder {
+//     let id = path.into_inner();
+//     match data
+//         .anime_service
+//         .delete_one(doc! {"_id": id.as_str()})
+//         .await
+//     {
+//         Ok(_) => Ok(HttpResponse::NoContent().finish()),
+//         Err(e) => Err(e),
+//     }
+// }

--- a/ponzu-back/src/env.rs
+++ b/ponzu-back/src/env.rs
@@ -1,3 +1,4 @@
+use std::any::type_name;
 use std::fmt::Debug;
 use std::str::FromStr;
 
@@ -19,7 +20,9 @@ where
         None => std::env::var(key).expect(&format!("{} environment variable not found", key)),
     };
     // Return the parsed value
-    unparsed
-        .parse::<T>()
-        .expect(&format!("Failed to parse {} as {:?}", key, T::from_str("")))
+    unparsed.parse::<T>().expect(&format!(
+        "Failed to parse {} as {:?}",
+        key,
+        type_name::<T>()
+    ))
 }

--- a/ponzu-back/src/main.rs
+++ b/ponzu-back/src/main.rs
@@ -1,11 +1,11 @@
 use crate::endpoints::default::default_responder;
 use crate::endpoints::scope::create_app_scope;
 use crate::env::get_from_env;
-use types::app_state::AppState;
 use actix_web::middleware::{Logger, NormalizePath, TrailingSlash};
 use actix_web::{web, App, HttpServer};
 use database::init_database;
 use dotenv::dotenv;
+use types::app_state::AppState;
 
 mod database;
 mod dto;
@@ -13,8 +13,8 @@ mod endpoints;
 mod env;
 mod models;
 mod services;
-mod utils;
 mod types;
+mod utils;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {

--- a/ponzu-back/src/models/user.rs
+++ b/ponzu-back/src/models/user.rs
@@ -9,7 +9,7 @@ use mongodb::bson::DateTime;
 use serde::{Deserialize, Serialize};
 
 /// User model
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct User {
     #[serde(
         rename = "_id",

--- a/ponzu-back/src/types/app_error.rs
+++ b/ponzu-back/src/types/app_error.rs
@@ -14,7 +14,7 @@ pub enum AppError {
 }
 
 impl fmt::Display for AppError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             AppError::MongoError(err) => write!(f, "MongoDB error: {}", err),
             AppError::NotFound(msg) => write!(f, "Not found: {}", msg),

--- a/ponzu-back/src/types/app_state.rs
+++ b/ponzu-back/src/types/app_state.rs
@@ -1,12 +1,77 @@
+use crate::dto::anime::{AnimeDto, CreateAnimeDto, UpdateAnimeDto};
+use crate::dto::character::{CharacterDto, CreateCharacterDto, UpdateCharacterDto};
+use crate::dto::club::{ClubDto, CreateClubDto, UpdateClubDto};
+use crate::dto::genre::{CreateGenreDto, GenreDto, UpdateGenreDto};
+use crate::dto::magazine::{CreateMagazineDto, MagazineDto, UpdateMagazineDto};
+use crate::dto::manga::{CreateMangaDto, MangaDto, UpdateMangaDto};
+use crate::dto::person::{CreatePersonDto, PersonDto, UpdatePersonDto};
+use crate::dto::producer::{CreateProducerDto, ProducerDto, UpdateProducerDto};
+use crate::dto::review::{CreateReviewDto, ReviewDto, UpdateReviewDto};
+use crate::dto::user::{RegisterUserDto, UpdateUserDto, UserDto};
+use crate::models::anime::Anime;
+use crate::models::character::Character;
+use crate::models::club::Club;
+use crate::models::genre::Genre;
+use crate::models::magazine::Magazine;
+use crate::models::manga::Manga;
+use crate::models::person::Person;
+use crate::models::producer::Producer;
+use crate::models::review::Review;
+use crate::models::user::User;
+use crate::services::crud::{CrudService, CrudServiceImpl};
+use crate::services::db_repo::DatabaseRepository;
 use mongodb::Database;
+use std::sync::Arc;
 
 /// The application state.
 pub struct AppState {
+    anime_service: CrudServiceImpl<Anime, AnimeDto, CreateAnimeDto, UpdateAnimeDto>,
+    character_service:
+        CrudServiceImpl<Character, CharacterDto, CreateCharacterDto, UpdateCharacterDto>,
+    club_service: CrudServiceImpl<Club, ClubDto, CreateClubDto, UpdateClubDto>,
+    genre_service: CrudServiceImpl<Genre, GenreDto, CreateGenreDto, UpdateGenreDto>,
+    magazine_service: CrudServiceImpl<Magazine, MagazineDto, CreateMagazineDto, UpdateMagazineDto>,
+    manga_service: CrudServiceImpl<Manga, MangaDto, CreateMangaDto, UpdateMangaDto>,
+    people_service: CrudServiceImpl<Person, PersonDto, CreatePersonDto, UpdatePersonDto>,
+    producer_service: CrudServiceImpl<Producer, ProducerDto, CreateProducerDto, UpdateProducerDto>,
+    review_service: CrudServiceImpl<Review, ReviewDto, CreateReviewDto, UpdateReviewDto>,
+    user_service: CrudServiceImpl<User, UserDto, RegisterUserDto, UpdateUserDto>,
 }
 
 impl AppState {
-    pub fn new(db: Database) -> Self {
+    pub fn new(db: Database) -> AppState {
         AppState {
+            anime_service: CrudServiceImpl::new(Arc::from(DatabaseRepository::new(
+                db.collection("anime"),
+            ))),
+            character_service: CrudServiceImpl::new(Arc::from(DatabaseRepository::new(
+                db.collection("characters"),
+            ))),
+            club_service: CrudServiceImpl::new(Arc::from(DatabaseRepository::new(
+                db.collection("clubs"),
+            ))),
+            genre_service: CrudServiceImpl::new(Arc::from(DatabaseRepository::new(
+                db.collection("genres"),
+            ))),
+            magazine_service: CrudServiceImpl::new(Arc::from(DatabaseRepository::new(
+                db.collection("magazines"),
+            ))),
+            manga_service: CrudServiceImpl::new(Arc::from(DatabaseRepository::new(
+                db.collection("manga"),
+            ))),
+            people_service: CrudServiceImpl::new(Arc::from(DatabaseRepository::new(
+                db.collection("people"),
+            ))),
+            producer_service: CrudServiceImpl::new(Arc::from(DatabaseRepository::new(
+                db.collection("producers"),
+            ))),
+            review_service: CrudServiceImpl::new(Arc::from(DatabaseRepository::new(
+                db.collection("reviews"),
+            ))),
+            user_service: CrudServiceImpl::new(Arc::from(DatabaseRepository::new(
+                db.collection("users"),
+            ))),
         }
     }
 }
+

--- a/ponzu-back/src/types/app_state.rs
+++ b/ponzu-back/src/types/app_state.rs
@@ -1,4 +1,3 @@
-use colored::Colorize;
 use mongodb::Database;
 
 /// The application state.
@@ -7,7 +6,6 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(db: Database) -> Self {
-        println!("{} {}!", "Initialized AppState with database".bright_green(), db.name());
         AppState {
         }
     }


### PR DESCRIPTION
This pull request introduces several new Data Transfer Object (DTO) structs and their associated implementations for various entities in the `ponzu-back` project. These changes are primarily aimed at improving the data handling and serialization/deserialization processes for these entities. The most important changes include the addition of DTOs for characters, clubs, genres, magazines, and persons, as well as updates to the module organization.

### New DTO Implementations:

* `ponzu-back/src/dto/character.rs`:
  * Added `CharacterDto`, `CharacterMediaDto`, `CharacterVoiceDto`, `CreateCharacterDto`, and `UpdateCharacterDto` structs.
  * Implemented `From` trait for conversions between `Character` and its DTOs.

* `ponzu-back/src/dto/club.rs`:
  * Added `ClubDto`, `CreateClubDto`, and `UpdateClubDto` structs.
  * Implemented `From` trait for conversions between `Club` and its DTOs.

* `ponzu-back/src/dto/genre.rs`:
  * Added `GenreDto`, `CreateGenreDto`, and `UpdateGenreDto` structs.
  * Implemented `From` trait for conversions between `Genre` and its DTOs.

* `ponzu-back/src/dto/magazine.rs`:
  * Added `MagazineDto`, `CreateMagazineDto`, and `UpdateMagazineDto` structs.
  * Implemented `From` trait for conversions between `Magazine` and its DTOs.

* `ponzu-back/src/dto/person.rs`:
  * Added `PersonDto`, `PersonMediaDto`, `PersonVoiceDto`, `CreatePersonDto`, and `UpdatePersonDto` structs.
  * Implemented `From` trait for conversions between `Person` and its DTOs.

### Module Organization:

* `ponzu-back/src/dto/mod.rs`:
  * Added new modules for anime, club, genre, magazine, manga, person, producer, review, and user.